### PR TITLE
[2023-05-29] feat : 클라이언트 매칭 페이지 및 자잘한 변경사항

### DIFF
--- a/api/instance.ts
+++ b/api/instance.ts
@@ -1,0 +1,22 @@
+import axios from "axios";
+
+const instance = axios.create({
+  baseURL: `http://localhost:3000/api/`,
+  timeout: 8000,
+  headers: {
+    "content-type": "application/json;charset=UTF-8",
+    accept: "application/json",
+  },
+});
+
+// axios response interceptors
+instance.interceptors.response.use(
+  function (response) {
+    return response;
+  },
+  function (err) {
+    return err;
+  },
+);
+
+export { instance };

--- a/api/modules/matching.ts
+++ b/api/modules/matching.ts
@@ -1,0 +1,17 @@
+import { instance } from "@/api/instance";
+
+export type MatchingsStatusType =
+  | "매칭대기중"
+  | "매칭중"
+  | "매칭완료"
+  | "진행중"
+  | "진행완료";
+
+export const get_matchings = async (matchingsStatus: MatchingsStatusType) => {
+  const response = await instance({
+    method: "get",
+    url: `matchings?status=${matchingsStatus}`,
+  });
+
+  return response;
+};

--- a/api/modules/user.ts
+++ b/api/modules/user.ts
@@ -1,0 +1,10 @@
+import { instance } from "@/api/instance";
+
+export const get_ping = async () => {
+  const response = await instance({
+    method: "get",
+    url: `pinga`,
+  });
+
+  return response;
+};

--- a/clientComponents/historyBackButton.tsx
+++ b/clientComponents/historyBackButton.tsx
@@ -1,0 +1,17 @@
+import { useRouter } from "next/router";
+import styled from "styled-components";
+
+const BackButton = styled.button`
+  width: 100%;
+  border: 1px solid #fff;
+  padding: 20px 0;
+  font-size: 20px;
+`;
+
+const HistoryBackButton = () => {
+  const router = useRouter();
+
+  return <BackButton onClick={() => router.back()}>뒤로가기</BackButton>;
+};
+
+export default HistoryBackButton;

--- a/clientComponents/index.ts
+++ b/clientComponents/index.ts
@@ -1,0 +1,3 @@
+import HistoryBackButton from "./historyBackButton";
+
+export { HistoryBackButton };

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
-}
+  reactStrictMode: false,
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/node": "20.2.1",
     "@types/react": "18.2.6",
     "@types/react-dom": "18.2.4",
+    "axios": "^1.4.0",
     "eslint": "8.41.0",
     "eslint-config-next": "13.4.3",
     "next": "13.4.3",

--- a/pages/client/application/index.styled.ts
+++ b/pages/client/application/index.styled.ts
@@ -16,6 +16,6 @@ export const CustomInput = styled.input`
   border: 1px solid #ccc;
 `;
 
-export const FormBox = styled.div`
+export const ApplicationPage = styled.div`
   width: 100%;
 `;

--- a/pages/client/application/index.tsx
+++ b/pages/client/application/index.tsx
@@ -1,22 +1,27 @@
 import { useState } from "react";
 import { useRouter } from "next/router";
 
-import { ApplicationButton, CustomInput, FormBox } from "./index.styled";
+import { HistoryBackButton } from "@/clientComponents";
+import {
+  ApplicationPage,
+  ApplicationButton,
+  CustomInput,
+} from "@/pages/client/application/index.styled";
 
-export const Application = () => {
+type StatusType = "날짜" | "장소" | "목적";
+type FormType = "date" | "text";
+
+interface FromInterface {
+  title: StatusType;
+  inputType: FormType;
+  value: string;
+  setValue: (state: string) => void;
+}
+
+const Application = () => {
   const router = useRouter();
 
-  type StatusType = "날짜" | "장소" | "목적";
-  type FormType = "date" | "text";
-
-  interface FromInterface {
-    title: StatusType;
-    inputType: FormType;
-    value: string;
-    setValue: (state: string) => void;
-  }
-
-  const [currentStatus, setCurrentStatus] = useState<StatusType>("날짜");
+  const [isCurrentFormIndex, setIsCurrentFormIndex] = useState<number>(0);
   const [time, setTime] = useState<string>("");
   const [location, setLocation] = useState<string>("");
   const [usage, setUsage] = useState<string>("");
@@ -42,8 +47,10 @@ export const Application = () => {
     },
   ];
 
-  const nextForm = (status: StatusType) => {
-    setCurrentStatus(status);
+  const lastFormindex = formList.length - 1;
+
+  const nextForm = (status: number) => {
+    setIsCurrentFormIndex(status + 1);
   };
 
   const submitApplication = (time: string, location: string, usage: string) => {
@@ -51,33 +58,67 @@ export const Application = () => {
     router.push("/client/matching");
   };
 
+  const submitButtonHandler = (currentIndex: number) => {
+    if (currentIndex === lastFormindex) {
+      submitApplication(time, location, usage);
+    } else {
+      nextForm(currentIndex);
+    }
+  };
+
   return (
-    <FormBox>
+    <ApplicationPage>
       {formList.map((form, idx) => {
-        if (currentStatus !== form.title) return;
         return (
-          <section key={idx}>
-            <h2>{form.title}를 입력해주세요</h2>
-            <CustomInput
-              type={form.inputType}
-              value={form.value}
-              onChange={(e: React.FormEvent<HTMLInputElement>) =>
-                form.setValue(e.currentTarget.value)
-              }
-            />
-            <ApplicationButton
-              onClick={() =>
-                currentStatus === "목적"
-                  ? submitApplication(time, location, usage)
-                  : nextForm(formList[idx + 1].title)
-              }
-            >
-              {currentStatus === "목적" ? "신청" : "다음"}
-            </ApplicationButton>
-          </section>
+          <AplicationForm
+            form={form}
+            key={form.title}
+            formIndex={idx}
+            lastFormIndex={formList.length - 1}
+            currentFormIndex={isCurrentFormIndex}
+            buttonHandler={submitButtonHandler}
+          />
         );
       })}
-    </FormBox>
+      <HistoryBackButton />
+    </ApplicationPage>
+  );
+};
+
+// ------------------------------ AplicationForm Comonent ---------------------------------
+interface AplicationFormInterface {
+  form: FromInterface;
+  formIndex: number;
+  lastFormIndex: number;
+  currentFormIndex: number;
+  buttonHandler: (index: number) => void;
+}
+
+const AplicationForm = ({
+  form,
+  formIndex,
+  lastFormIndex,
+  currentFormIndex,
+  buttonHandler,
+}: AplicationFormInterface): JSX.Element | null => {
+  const AplicationButtonText =
+    currentFormIndex === lastFormIndex ? "신청" : "다음";
+
+  if (currentFormIndex !== formIndex) return null;
+  return (
+    <div key={form.title}>
+      <h2>{form.title}를 입력해주세요</h2>
+      <CustomInput
+        type={form.inputType}
+        value={form.value}
+        onChange={(e: React.FormEvent<HTMLInputElement>) =>
+          form.setValue(e.currentTarget.value)
+        }
+      />
+      <ApplicationButton onClick={() => buttonHandler(currentFormIndex)}>
+        {AplicationButtonText}
+      </ApplicationButton>
+    </div>
   );
 };
 

--- a/pages/client/index.tsx
+++ b/pages/client/index.tsx
@@ -8,7 +8,7 @@ const NavButton = styled.button`
   font-size: 20px;
 `;
 
-export const Client = () => {
+const Client = () => {
   const router = useRouter();
 
   return (

--- a/pages/client/matching/index.tsx
+++ b/pages/client/matching/index.tsx
@@ -1,29 +1,126 @@
 import { useEffect, useState } from "react";
-import { StatusButton } from "./index.styled";
+import { useRouter } from "next/router";
+import Image from "next/image";
 
-export const Matching = () => {
-  const [qrCode, setQrCode] = useState<string | null>(null);
-  const [progress, setProgress] = useState<number>(0);
+import { get_matchings } from "@/api/modules/matching";
+import { MatchingsStatusType } from "@/api/modules/matching";
 
-  const getQrCode = async () => {
-    console.log("get QrCode");
-  };
+import { HistoryBackButton } from "@/clientComponents";
+import { StatusButton } from "@/pages/client/matching/index.styled";
+
+interface MatchingInfoInterface {
+  _id: string;
+  publishUserId: string;
+  statusType: MatchingsStatusType;
+  clothesType: string; // 만약 백엔드 enum이 있다면 상수로 교체
+  limitPrice: number;
+  preferPlace: string;
+  preferStyle: string; // 만약 백엔드 enum이 있다면 상수로 교체
+  preferGender: "woman" | "man";
+  remark: string;
+  uuid: string;
+  createdAt: string;
+  qrCodeValue: string;
+}
+
+const Matching = () => {
+  // 임시 state와 fn 이후 통 삭제 필요
+  const [index, setIndex] = useState(0);
+  const stepList = ["매칭대기중", "매칭중", "매칭완료", "진행중", "진행완료"];
+  const [step, setStep] = useState(stepList[0]);
+  const currentProgress = step;
 
   useEffect(() => {
+    if (index === 2) alert("매칭되었습니다.");
+    if (index === 5) alert("완료되었습니다.");
+  }, [index]);
+  // --------------
+  const router = useRouter();
+
+  const [matchingInfo, setMatchingInfo] = useState<MatchingInfoInterface>();
+  const [qrCode, setQrCode] = useState<string>("");
+
+  const getCurrentMatching = async () => {
+    const { data } = await get_matchings("매칭대기중");
+    setMatchingInfo(data.matchings[0]);
+    setQrCode(data.matchings[0].qrCodeValue);
+  };
+
+  const getQrCode = async () => {
+    const { data } = await get_matchings("매칭대기중");
+  };
+
+  /**
+   * 이후 하나의 함수에서 awiat로 순차적 진행
+   * getCurrentMatching 으로 uuid를 받은다음 해당 uuid에 QR코드를 가져옴
+   * getCurrentMatching은 한번 콜 이후 1분마다 폴링방식으로 서버와 통신
+   * 아니면 BE에서 현재 클라이언트 측에서 진행중인 매칭만 get 하는 API 필요
+   */
+  useEffect(() => {
+    getCurrentMatching();
     getQrCode();
   }, []);
 
+  /**
+   * 얼리리턴을 스크린리더기가 어떻게 반응하는지 체크가 필요함
+   * 만약 CSR에서 스크린리더기가 정상적으로 동작하지 않는다면?
+   * 클라이언트 페이지 사이드는 SSR이 될 가능성이 높음
+   */
+  if (matchingInfo === null) {
+    return (
+      <div>
+        <div>진행상황이 없습니다.</div>
+        <HistoryBackButton />
+      </div>
+    );
+  }
+
+  const currentMatchingCancelHandler = () => {
+    if (confirm("취소하시겠습니까?")) {
+      alert("취소되었습니다.");
+      router.push("/client");
+    }
+  };
+
+  // const currentProgress = matchingInfo?.statusType;
+  const limitPrice = matchingInfo?.limitPrice;
+  const preferPlace = matchingInfo?.preferPlace;
+  const clothesType = matchingInfo?.clothesType;
+  const preferStyle = matchingInfo?.preferStyle;
+  const preferGender = matchingInfo?.preferGender;
+  const remark = matchingInfo?.remark;
+
   return (
     <div>
-      <div>스탭버튼</div>
+      <div
+        onClick={() => {
+          console.log(index);
+          setIndex(index + 1);
+          setStep(stepList[index]);
+        }}
+      >
+        스탭버튼
+      </div>
       <h2>신청현황</h2>
       <ul>
-        <li>1월 31일 12:30</li>
-        <li>영등포역</li>
-        <li>면접장소</li>
+        <li>장소 : {preferPlace}</li>
+        <li>성별 : {preferGender}</li>
+        <li>스타일 : {preferStyle}</li>
+        <li>구매필요 : {clothesType}</li>
+        <li>한도금액 : {limitPrice}</li>
+        <li>비고 : {remark}</li>
+        <li>진행상태 : {currentProgress}</li>
       </ul>
-      <div>진행상태 : 매칭중</div>
-      <StatusButton>신청취소</StatusButton>
+      {currentProgress === "매칭완료" && (
+        <Image src={qrCode} alt="Picture of me" width={100} height={100} />
+      )}
+      {currentProgress !== "진행중" && currentProgress !== "진행완료" && (
+        <StatusButton onClick={currentMatchingCancelHandler}>
+          신청취소
+        </StatusButton>
+      )}
+      {currentProgress === "진행완료" && <button>완료</button>}
+      <HistoryBackButton />
     </div>
   );
 };

--- a/pages/client/mypage/index.tsx
+++ b/pages/client/mypage/index.tsx
@@ -1,0 +1,15 @@
+import { HistoryBackButton } from "@/clientComponents/index";
+
+const Mypage = () => {
+  return (
+    <div>
+      <div>강서구 스트릿 스타일링 완료</div>
+      <div>강서구 스트릿 스타일링 완료</div>
+      <div>강서구 스트릿 스타일링 완료</div>
+      <div>강서구 스트릿 스타일링 완료</div>
+      <HistoryBackButton />
+    </div>
+  );
+};
+
+export default Mypage;

--- a/utils/toBase64.ts
+++ b/utils/toBase64.ts
@@ -1,0 +1,24 @@
+const toBase64 = (file: Blob) =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = (base64: ProgressEvent<FileReader> | null) => {
+      const image = new Image();
+
+      image.src = String(base64?.target?.result);
+
+      image.onload = (e: any) => {
+        const canvas = document.createElement(`canvas`);
+        const ctx: CanvasRenderingContext2D | null = canvas.getContext(`2d`);
+
+        canvas.width = e.target.width;
+        canvas.height = e.target.height;
+
+        ctx?.drawImage(e.target, 0, 0);
+        resolve(canvas.toDataURL(`image/jpeg`, 0.5));
+      };
+    };
+    reader.onerror = err => reject(err);
+  });
+
+export { toBase64 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -528,6 +528,11 @@ ast-types-flow@^0.0.7:
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
   integrity sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 available-typed-arrays@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
@@ -537,6 +542,15 @@ axe-core@^4.6.2:
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.7.1.tgz#04392c9ccb3d7d7c5d2f8684f148d56d3442f33d"
   integrity sha512-sCXXUhA+cljomZ3ZAwb8i1p3oOlkABzPy08ZDAoGcYuvtBPlQ1Ytde129ArXyHWDhfeewq7rlx9F+cUx2SSlkg==
+
+axios@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
+  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^3.1.1:
   version "3.1.1"
@@ -676,6 +690,13 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -787,6 +808,11 @@ define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0:
   dependencies:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -1215,12 +1241,26 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
+follow-redirects@^1.15.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1785,6 +1825,18 @@ micromatch@^4.0.4:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -2063,6 +2115,11 @@ prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.3.0"


### PR DESCRIPTION
- axios 설치후 간단하게 instance 파일 만들어서 url 고정했습니다. 인터셉터는 만들어놨는데, 크게 쓸일은 없을것 같습니다.
- axios modules는 BE에서 주신 인섬니아 기반으로 user,matching,matchingStauts로 나누었습니다. 역할별로 나눈거같긴한데 더 좋은 방법있으면 말씀해주시면 감사하겠습니다.

- api/modules/matching.ts 에서 MatchingsStatusType 을 지정했는데, 해당 타입은 클라이언트와 서버 동시에 사용할거같아 공용타입폴더를 만들면 어떨까 싶습니다.

- clientComponents 폴더를 만들었는데, 서버 컴포넌트가 디렉토리 구조상 아래에있어 보기 힘들거같아 components > 이후 서버와 클라이언트 컴포넌트 폴더로 디렉토리를 변경하면 좋을거같습니다.

- next.config.js 스트릭트모드 해제했습니다. 혹시 사용하는게 더 편하시다면 돌려주셔도 무방합니다.

- pages/client/application/index.tsx 지난번에 말씀하신 상수값으로 마지막 신청인지 모르겠다고하셔서 index를 current와 last로 만들어봤는데 저는 먼가 더 어지러운거같습니다. 

-pages/client/matching/index.tsx 간단하게 매칭리스트중 가장 첫번째인거 받아서 각각 단계표시만 했습니다. 안내컨펌은 모달로할지 방식을 정해야할거같아 그냥 컨펌으로 했습니다.

- utils/toBase64.ts 추후 서버페이지에서 이미지 보내실때 base64인코딩용 함수입니다.